### PR TITLE
Fix potential crashes around dynamic casts

### DIFF
--- a/document/buffer/qmemoryrefbuffer.cpp
+++ b/document/buffer/qmemoryrefbuffer.cpp
@@ -1,5 +1,7 @@
 #include "qmemoryrefbuffer.h"
 
+#include <QObject>
+
 QMemoryRefBuffer::QMemoryRefBuffer(QObject *parent): QHexBuffer(parent) { }
 int QMemoryRefBuffer::length() const { return m_buffer->size(); }
 void QMemoryRefBuffer::insert(int, const QByteArray &) { /* Insertion unsupported */ }
@@ -11,7 +13,7 @@ QByteArray QMemoryRefBuffer::read(int offset, int length)
     return m_buffer->read(length);
 }
 
-void QMemoryRefBuffer::read(QIODevice *device) { m_buffer = dynamic_cast<QBuffer*>(device); }
+void QMemoryRefBuffer::read(QIODevice *device) { m_buffer = qobject_cast<QBuffer*>(device); }
 
 void QMemoryRefBuffer::write(QIODevice *device)
 {

--- a/document/qhexrenderer.cpp
+++ b/document/qhexrenderer.cpp
@@ -15,12 +15,7 @@ QHexRenderer::QHexRenderer(QHexDocument* document, const QFontMetrics &fontmetri
 
 void QHexRenderer::renderFrame(QPainter *painter)
 {
-    QWidget* widget = dynamic_cast<QWidget*>(painter->device());
-
-    if(!widget)
-        return;
-
-    QRect rect = widget->rect();
+    QRect rect = painter->window();
     int hexx = this->getHexColumnX();
     int asciix = this->getAsciiColumnX();
     int endx = this->getEndColumnX();


### PR DESCRIPTION
The cast in `QMemoryRefBuffer::read()` is not particularly critical but using `qobject_cast` lets downstream users turn off RTTI. The other cast in `QHexRenderer::renderFrame()` was causing a pretty nasty crash on OSX, but it seems like it's not needed at all because we can just use `window()` from `QPainter`.