### PR TITLE
Fix std::isprint

### DIFF
--- a/document/qhexrenderer.cpp
+++ b/document/qhexrenderer.cpp
@@ -201,7 +201,7 @@ void QHexRenderer::unprintableChars(QByteArray &ascii) const
 {
     for(char& ch : ascii)
     {
-        if(std::isprint(ch))
+        if(std::isprint(static_cast<unsigned char>(ch)))
             continue;
 
         ch = HEX_UNPRINTABLE_CHAR;


### PR DESCRIPTION
std:isprint expect something that fit on a unsigned char and that trigger an assert with msvc if you pass a simple char