### PR TITLE
Only display comments on the commented bytes, not the whole line.

### DIFF
--- a/document/qhexmetadata.cpp
+++ b/document/qhexmetadata.cpp
@@ -8,7 +8,7 @@ const QHexLineMetadata &QHexMetadata::get(int line) const
     return it.value();
 }
 
-QString QHexMetadata::comments(int line) const
+QString QHexMetadata::comments(int line, int column) const
 {
     if(!this->hasMetadata(line))
         return QString();
@@ -19,6 +19,8 @@ QString QHexMetadata::comments(int line) const
 
     for(auto& mi : linemetadata)
     {
+        if(!(mi.start <= column && column < mi.start + mi.length))
+            continue;
         if(mi.comment.isEmpty())
             continue;
 

--- a/document/qhexmetadata.h
+++ b/document/qhexmetadata.h
@@ -22,7 +22,7 @@ class QHexMetadata : public QObject
     public:
         explicit QHexMetadata(QObject *parent = nullptr);
         const QHexLineMetadata& get(int line) const;
-        QString comments(int line) const;
+        QString comments(int line, int column) const;
         bool hasMetadata(int line) const;
         void clear(int line);
         void clear();

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -78,7 +78,7 @@ bool QHexView::event(QEvent *e)
 
         if(m_renderer->hitTest(helpevent->pos(), &position, this->firstVisibleLine()))
         {
-            QString comments = m_document->metadata()->comments(position.line);
+            QString comments = m_document->metadata()->comments(position.line, position.column);
 
             if(!comments.isEmpty())
                 QToolTip::showText(helpevent->globalPos(), comments, this);


### PR DESCRIPTION
This allows having different comments for different bytes in the same line.