### PR TITLE
Fix integer overflow in firstVisibleLine()

### DIFF
--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -636,7 +636,7 @@ void QHexView::renderLine(quint64 line)
 
 quint64 QHexView::firstVisibleLine() const
 {
-    quint64 value = this->verticalScrollBar()->value() * documentSizeFactor();
+    quint64 value = quint64(this->verticalScrollBar()->value()) * documentSizeFactor();
     return value;
 }
 


### PR DESCRIPTION
An integer overflow occurs while viewing files larger than 34GB's. This causes the widget to not render anything when the first visible line is beyond 0x7ffffffff (note that this is 8 f's).

![image](https://user-images.githubusercontent.com/12718188/101261058-e4e68000-36f9-11eb-911c-4f75a186a6ac.png)

Scrolling past 0x800000000:
![image](https://user-images.githubusercontent.com/12718188/101261099-3b53be80-36fa-11eb-892b-6837eb964f97.png)

