### PR TITLE
Fix off by one in QHexView::paintEvent.

### DIFF
--- a/document/qhexrenderer.cpp
+++ b/document/qhexrenderer.cpp
@@ -41,15 +41,14 @@ void QHexRenderer::renderFrame(QPainter *painter)
                       rect.bottom());
 }
 
-void QHexRenderer::render(QPainter *painter, quint64 start, int count, quint64 firstline)
+void QHexRenderer::render(QPainter *painter, quint64 begin, quint64 end, quint64 firstline)
 {
-    quint64 end = start + count;
     QPalette palette = qApp->palette();
 
     drawHeader(painter, palette);
 
     quint64 documentLines = this->documentLines();
-    for(quint64 line = start; line < std::min(end, documentLines); line++)
+    for(quint64 line = begin; line < std::min(end, documentLines); line++)
     {
         QRect linerect = this->getLineRect(line, firstline);
 

--- a/document/qhexrenderer.h
+++ b/document/qhexrenderer.h
@@ -21,7 +21,7 @@ class QHexRenderer : public QObject
     public:
         explicit QHexRenderer(QHexDocument* document, const QFontMetrics& fontmetrics, QObject *parent = nullptr);
         void renderFrame(QPainter* painter);
-        void render(QPainter* painter, quint64 start, int count, quint64 firstline);
+        void render(QPainter* painter, quint64 start, quint64 end, quint64 firstline);  // begin included, end excluded
         void enableCursor(bool b = true);
         void selectArea(const QPoint& pt);
 

--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -246,12 +246,22 @@ void QHexView::paintEvent(QPaintEvent *e)
     painter.setFont(this->font());
 
     const QRect& r = e->rect();
-    quint64 firstvisible = this->firstVisibleLine();
-    quint64 first = firstvisible + (r.top() / m_renderer->lineHeight());
-    quint64 last = firstvisible + (r.bottom() / m_renderer->lineHeight());
-    int count = static_cast<int>((last - first) - m_renderer->headerLineCount());
 
-    m_renderer->render(&painter, first, count, firstvisible);
+    const quint64 firstVisible = this->firstVisibleLine();
+    const int lineHeight = m_renderer->lineHeight();
+    const int headerCount = m_renderer->headerLineCount();
+
+    // these are lines from the point of view of the visible rect
+    // where the first "headerCount" are taken by the header
+    const int first = (r.top() / lineHeight);  // included
+    const int lastPlusOne = (r.bottom() / lineHeight) + 1;  // excluded
+
+    // compute document lines, adding firstVisible and removing the header
+    // the max is necessary if the rect covers the header
+    const quint64 begin = firstVisible + std::max(first - headerCount, 0);
+    const quint64 end = firstVisible + std::max(lastPlusOne - headerCount, 0) ;
+
+    m_renderer->render(&painter, begin, end, firstVisible);
     m_renderer->renderFrame(&painter);
 }
 


### PR DESCRIPTION
Lines are shifted by the header count (rather than the count).

Moreover, simplify the logic and pass "begin" and "end" (same convention as the stl),
rather than "first" and "count" (which was reconverted in QHexRenderer::render).