### PR TITLE
Minor coding improvements

### DIFF
--- a/document/buffer/qfilebuffer.cpp
+++ b/document/buffer/qfilebuffer.cpp
@@ -26,10 +26,14 @@ qint64 QFileBuffer::length() const {
 }
 
 void QFileBuffer::insert(qint64 offset, const QByteArray &data) {
+    Q_UNUSED(offset)
+    Q_UNUSED(data)
     // Not implemented
 }
 
 void QFileBuffer::remove(qint64 offset, int length) {
+    Q_UNUSED(offset)
+    Q_UNUSED(length)
     // Not implemented
 }
 
@@ -52,6 +56,7 @@ bool QFileBuffer::read(QIODevice *device) {
 }
 
 void QFileBuffer::write(QIODevice *device) {
+    Q_UNUSED(device)
     // Not implemented
 }
 

--- a/document/qhexmetadata.cpp
+++ b/document/qhexmetadata.cpp
@@ -2,13 +2,13 @@
 
 QHexMetadata::QHexMetadata(QObject *parent) : QObject(parent) { }
 
-const QHexLineMetadata &QHexMetadata::get(int line) const
+const QHexLineMetadata &QHexMetadata::get(quint64 line) const
 {
     auto it = m_metadata.find(line);
     return it.value();
 }
 
-QString QHexMetadata::comments(int line, int column) const
+QString QHexMetadata::comments(quint64 line, int column) const
 {
     if(!this->hasMetadata(line))
         return QString();
@@ -33,9 +33,9 @@ QString QHexMetadata::comments(int line, int column) const
     return s;
 }
 
-bool QHexMetadata::hasMetadata(int line) const { return m_metadata.contains(line); }
+bool QHexMetadata::hasMetadata(quint64 line) const { return m_metadata.contains(line); }
 
-void QHexMetadata::clear(int line)
+void QHexMetadata::clear(quint64 line)
 {
     auto it = m_metadata.find(line);
 
@@ -61,10 +61,10 @@ void QHexMetadata::metadata(qint64 begin, qint64 end, const QColor &fgcolor, con
 
 void QHexMetadata::setAbsoluteMetadata(const QHexMetadataAbsoluteItem& mai)
 {
-    const int firstRow = mai.begin / m_lineWidth;
-    const int lastRow = mai.end / m_lineWidth;
+    const quint64 firstRow = mai.begin / m_lineWidth;
+    const quint64 lastRow = mai.end / m_lineWidth;
 
-    for (int row = firstRow; row <= lastRow; ++row)
+    for (quint64 row = firstRow; row <= lastRow; ++row)
     {
         int start, length;
         if (row == firstRow)
@@ -106,7 +106,7 @@ void QHexMetadata::setLineWidth(quint8 width)
     }
 }
 
-void QHexMetadata::metadata(int line, int start, int length, const QColor &fgcolor, const QColor &bgcolor, const QString &comment)
+void QHexMetadata::metadata(quint64 line, int start, int length, const QColor &fgcolor, const QColor &bgcolor, const QString &comment)
 {
     const qint64 begin = line * m_lineWidth + start;
     const qint64 end = begin + length;
@@ -114,22 +114,22 @@ void QHexMetadata::metadata(int line, int start, int length, const QColor &fgcol
     this->metadata(begin, end, fgcolor, bgcolor, comment);
 }
 
-void QHexMetadata::color(int line, int start, int length, const QColor &fgcolor, const QColor &bgcolor)
+void QHexMetadata::color(quint64 line, int start, int length, const QColor &fgcolor, const QColor &bgcolor)
 {
     this->metadata(line, start, length, fgcolor, bgcolor, QString());
 }
 
-void QHexMetadata::foreground(int line, int start, int length, const QColor &fgcolor)
+void QHexMetadata::foreground(quint64 line, int start, int length, const QColor &fgcolor)
 {
     this->color(line, start, length, fgcolor, QColor());
 }
 
-void QHexMetadata::background(int line, int start, int length, const QColor &bgcolor)
+void QHexMetadata::background(quint64 line, int start, int length, const QColor &bgcolor)
 {
     this->color(line, start, length, QColor(), bgcolor);
 }
 
-void QHexMetadata::comment(int line, int start, int length, const QString &comment)
+void QHexMetadata::comment(quint64 line, int start, int length, const QString &comment)
 {
     this->metadata(line, start, length, QColor(), QColor(), comment);
 }

--- a/document/qhexmetadata.h
+++ b/document/qhexmetadata.h
@@ -17,7 +17,8 @@ struct QHexMetadataAbsoluteItem
 
 struct QHexMetadataItem
 {
-    int line, start, length;
+    quint64 line;
+    int start, length;
     QColor foreground, background;
     QString comment;
 };
@@ -34,11 +35,11 @@ class QHexMetadata : public QObject
 
     public:
         explicit QHexMetadata(QObject *parent = nullptr);
-        const QHexLineMetadata& get(int line) const;
-        QString comments(int line, int column) const;
-        bool hasMetadata(int line) const;
+        const QHexLineMetadata& get(quint64 line) const;
+        QString comments(quint64 line, int column) const;
+        bool hasMetadata(quint64 line) const;
 
-        void clear(int line); // this is transient till next call to setLineWidth()
+        void clear(quint64 line); // this is transient till next call to setLineWidth()
 
         void clear();
         void setLineWidth(quint8 width);
@@ -48,23 +49,23 @@ class QHexMetadata : public QObject
         void metadata(qint64 begin, qint64 end, const QColor &fgcolor, const QColor &bgcolor, const QString &comment);
 
         // old interface with line, start, length
-        void metadata(int line, int start, int length, const QColor& fgcolor, const QColor& bgcolor, const QString& comment);
-        void color(int line, int start, int length, const QColor& fgcolor, const QColor& bgcolor);
-        void foreground(int line, int start, int length, const QColor& fgcolor);
-        void background(int line, int start, int length, const QColor& bgcolor);
-        void comment(int line, int start, int length, const QString &comment);
+        void metadata(quint64 line, int start, int length, const QColor& fgcolor, const QColor& bgcolor, const QString& comment);
+        void color(quint64 line, int start, int length, const QColor& fgcolor, const QColor& bgcolor);
+        void foreground(quint64 line, int start, int length, const QColor& fgcolor);
+        void background(quint64 line, int start, int length, const QColor& bgcolor);
+        void comment(quint64 line, int start, int length, const QString &comment);
 
     private:
         void setMetadata(const QHexMetadataItem& mi);
         void setAbsoluteMetadata(const QHexMetadataAbsoluteItem& mi);
 
     signals:
-        void metadataChanged(int line);
+        void metadataChanged(quint64 line);
         void metadataCleared();
 
     private:
         quint8 m_lineWidth;
-        QHash<int, QHexLineMetadata> m_metadata;
+        QHash<quint64, QHexLineMetadata> m_metadata;
         QVector<QHexMetadataAbsoluteItem> m_absoluteMetadata;
 };
 


### PR DESCRIPTION
- use quint64 for lines in QHexMetadata
- mark a few function arguments with Q_UNUSED
