### PR TITLE
StyleHint is not a bit-enum.

### DIFF
--- a/qhexview.cpp
+++ b/qhexview.cpp
@@ -16,7 +16,7 @@ QHexView::QHexView(QWidget *parent) : QAbstractScrollArea(parent), m_document(nu
 {
     QFont f = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 
-    if(!(f.styleHint() & QFont::Monospace))
+    if(f.styleHint() != QFont::TypeWriter)
     {
         f.setFamily("Monospace"); // Force Monospaced font
         f.setStyleHint(QFont::TypeWriter);


### PR DESCRIPTION
Values must be compared for equality.
On a Pi4 the font comes back as AnyStyle and rendering is all over the place.
Moreover, what really fixes it is the family.