### PR TITLE
Enforce minimum C++ standard for Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,5 +20,6 @@ add_library(qhexview-lib STATIC
     qhexview.cpp
 )
 
+target_compile_features(qhexview-lib PUBLIC cxx_std_11)
 target_link_libraries(qhexview-lib PRIVATE Qt5::Widgets)
 target_include_directories(qhexview-lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
For some reason, when using the xcode generator AppleClang does not default to C++11 (nor does it inherit Qt's std setting) and thus will trigger Qt's guard for C++11, making compilation fail.
This sets the minimum required standard version explicitly as a workaround.