### PR TITLE
Use std::list in place of QLinkedList on recent Qt versions

### DIFF
--- a/document/qhexmetadata.h
+++ b/document/qhexmetadata.h
@@ -1,8 +1,13 @@
 #ifndef QHEXMETADATA_H
 #define QHEXMETADATA_H
 
-#include <QLinkedList>
+#include <QtGlobal>
 #include <QObject>
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+#include <QLinkedList>
+#else
+#include <list>
+#endif
 #include <QColor>
 #include <QHash>
 #include <QVector>


### PR DESCRIPTION
This fixes building under Qt6 which has dropped QLinkedList. It might be a good idea to rewrite these bits to use std::vector (or QVector) for performance, however this gets things compiling with minimal changes. 