### PR TITLE
Fix missing MOC generation for correct including

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(QHexView)
+project(QHexView
+    LANGUAGES CXX
+)
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
@@ -20,6 +22,11 @@ add_library(qhexview-lib STATIC
     qhexview.cpp
 )
 
-target_compile_features(qhexview-lib PUBLIC cxx_std_11)
+set_target_properties(qhexview-lib PROPERTIES
+    AUTOMOC ON
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
+
 target_link_libraries(qhexview-lib PRIVATE Qt5::Widgets)
 target_include_directories(qhexview-lib PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
If you try to use clean code programming using CMake you will not pollute global namespace with unnessesary variables.  
For using this library user had to and newbie developers usually do define something like this:
```cmake
set(CMAKE_AUTOMOC ON)
set(CMAKE_AUTOUIC ON)
set(CMAKE_AUTORCC ON)
```
You could see this many times in various tutorials and sample projects.  
More correct way is to define variables like `AUTOMOC` on per project basis library using `set_target_property` command.

As for define required C++ standard since you do not use specific compiler's features you can use `CXX_STANDARD` variable as for portable. Again on per project basic.

Since you do use `C` language (defined by default) you need to define list of used languages (only C++ usually). This will increase CMake configure time especially if users of library also uses only C++ in Qt projects